### PR TITLE
fix for tooling errors

### DIFF
--- a/src/tailwind.ts
+++ b/src/tailwind.ts
@@ -1,9 +1,10 @@
 import { DEFAULT_RECIPE_NAME } from "./constants";
 import { GetCssFromTailwindOptions } from "./types";
+import twTypography from "@tailwindcss/typography"
 
 // TODO: Quite a mess. Maybe clean up?
 export function getCssFromTailwind(options?: GetCssFromTailwindOptions) {
-  const cfg = (require("@tailwindcss/typography")() as any).config.theme
+  const cfg = (twTypography() as any).config.theme
     .typography;
   // Map all the necessary styles next to each other for easy processing
   const css = {


### PR DESCRIPTION
All my tooling regarding panda stopped working as soon as I added this preset. That is `@pandabox/prettier-plugin`, `@pandacss/eslint-plugin` and the [VS Code plugin](https://github.com/chakra-ui/panda-vscode). The error was all the same, related to `node-eval`. This fixed it for me on all instances.